### PR TITLE
Changing user dob start time

### DIFF
--- a/fraud/features/user_date_of_birth.py
+++ b/fraud/features/user_date_of_birth.py
@@ -10,7 +10,8 @@ from datetime import datetime
     mode='pyspark',
     online=True,
     offline=True,
-    feature_start_time=datetime(2020, 1, 1),
+    # Note the timestamp is the signup date, hence the old start_time.
+    feature_start_time=datetime(2017,1, 1),
     batch_schedule='1d',
     ttl='3650days',
     family='fraud',


### PR DESCRIPTION
We need to do this since the user dob feature uses the signup_date field as the timestamp, and that ranges from 7/29/2017 to 5/28/2020.