### PR TITLE
Remove cluster config

### DIFF
--- a/fraud/features/batch_feature_views/user_has_good_credit_pyspark.py
+++ b/fraud/features/batch_feature_views/user_has_good_credit_pyspark.py
@@ -12,10 +12,6 @@ from datetime import datetime
     offline=False,
     feature_start_time=datetime(2021, 1, 1),
     batch_schedule='1d',
-    batch_cluster_config = DatabricksClusterConfig(
-        instance_type = 'm5.2xlarge',
-        spark_config = {"spark.executor.memory" : "12g"}
-    ),
     ttl='120d',
     backfill_config=BackfillConfig("multiple_batch_schedule_intervals_per_job"),
     family='fraud',

--- a/fraud/features/batch_feature_views/user_has_good_credit_pyspark.py
+++ b/fraud/features/batch_feature_views/user_has_good_credit_pyspark.py
@@ -1,4 +1,4 @@
-from tecton import batch_feature_view, Input, DatabricksClusterConfig, BackfillConfig
+from tecton import batch_feature_view, Input, BackfillConfig
 from fraud.entities import user
 from fraud.data_sources.credit_scores_batch import credit_scores_batch
 from datetime import datetime

--- a/fraud/features/batch_feature_views/user_has_good_credit_sql.py
+++ b/fraud/features/batch_feature_views/user_has_good_credit_sql.py
@@ -1,4 +1,4 @@
-from tecton import batch_feature_view, Input, DatabricksClusterConfig, BackfillConfig
+from tecton import batch_feature_view, Input, BackfillConfig
 from fraud.entities import user
 from fraud.data_sources.credit_scores_batch import credit_scores_batch
 from datetime import datetime
@@ -12,10 +12,6 @@ from datetime import datetime
     offline=True,
     feature_start_time=datetime(2021, 1, 1),
     batch_schedule='1d',
-    batch_cluster_config = DatabricksClusterConfig(
-        instance_type = 'm5.2xlarge',
-        spark_config = {"spark.executor.memory" : "12g"}
-    ),
     ttl='120d',
     backfill_config=BackfillConfig("multiple_batch_schedule_intervals_per_job"),
     family='fraud',

--- a/fraud/features/batch_feature_views/user_has_great_credit.py
+++ b/fraud/features/batch_feature_views/user_has_great_credit.py
@@ -3,19 +3,14 @@ from fraud.entities import user
 from fraud.data_sources.credit_scores_batch import credit_scores_batch
 from datetime import datetime
 
-
 # @batch_feature_view(
 #     inputs={'credit_scores': Input(credit_scores_batch)},
 #     entities=[user],
 #     mode='spark_sql',
 #     online=True,
 #     offline=True,
-#     feature_start_time=datetime(2020, 10, 10),
+#     feature_start_time=datetime(2021, 1, 1),
 #     batch_schedule='1d',
-#     batch_cluster_config = DatabricksClusterConfig(
-#         instance_type = 'm5.2xlarge',
-#         spark_config = {"spark.executor.memory" : "12g"}
-#     ),
 #     ttl='30days',
 #     backfill_config=BackfillConfig("multiple_batch_schedule_intervals_per_job"),
 #     family='fraud',

--- a/fraud/features/batch_feature_views/user_has_great_credit.py
+++ b/fraud/features/batch_feature_views/user_has_great_credit.py
@@ -1,4 +1,4 @@
-from tecton import batch_feature_view, Input, DatabricksClusterConfig, BackfillConfig
+from tecton import batch_feature_view, Input, BackfillConfig
 from fraud.entities import user
 from fraud.data_sources.credit_scores_batch import credit_scores_batch
 from datetime import datetime


### PR DESCRIPTION
Previously materialization failed for these feature views with driver OOM errors. Now that materializing to online store requires less memory, we don't need to override the spark configuration.