### PR TITLE
Update user_distinct_ad_count_7d start_time_offset

### DIFF
--- a/ads/features/batch_features/user_distinct_ad_count_7d.py
+++ b/ads/features/batch_features/user_distinct_ad_count_7d.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 
 @batch_feature_view(
-    sources=[FilteredSource(ad_impressions_batch)],
+    sources=[FilteredSource(ad_impressions_batch, start_time_offset=timedelta(days=-6))],
     entities=[user],
     mode='spark_sql',
     ttl=timedelta(days=1),


### PR DESCRIPTION
The current configuration will only provide 1 days worth of data for each materialization because `batch_schedule` is `timedelta(days=1)`. In order to aggregate the distinct count over 7 days, an additional 6 days of historical data is needed.'

Relevant docs:
* https://docs.tecton.ai/docs/defining-features/feature-views/batch-feature-view#filtering-using-the-filteredsource-class
* https://docs.tecton.ai/docs/defining-features/feature-views/batch-feature-view/simplifying-custom-batch-aggregations-with-incremental-backfills